### PR TITLE
Add refresh

### DIFF
--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -28,4 +28,8 @@ Puppet::Type.newtype(:puppet_certificate) do
     desc "Alternate DNS names by which the certificate holder may be reached"
   end
 
+  def refresh
+      provider.destroy
+      provider.create
+  end
 end


### PR DESCRIPTION
This adds refresh support to the `puppet_certificate` type, allowing certificates to be recreated when triggered by another resource.

An example of usage is to regenerate certificates when the `csr_attributes.yaml` file is modified:

```puppet
    file { "${confdir}/puppet/csr_attributes.yaml":
      ensure  => file,
      owner   => 'root',
      group   => 'root',
      mode    => '0440',
      content => template('blah/csr_attributes.yaml.erb'),
    }
    ~> puppet_certificate { $certname:
      ensure               => present,
      waitforcert          => 60,
    }
```