### PR TITLE
Ensure valid

### DIFF
--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -24,8 +24,10 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   end
 
   def submit_csr
-    # Not implemented. Maybe it would look something like
-    # Puppet::SSL::CertificateRequest.indirection.save(csr)
+      begin
+          Puppet::SSL::CertificateRequest.indirection.save(csr)
+      rescue ArgumentError
+      end
   end
 
   def retrieve_certificate

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     unless key
       debug "generating new key for #{@resource[:name]}"
       ensure_cadir if ca_location == 'local'
+      Puppet::SSL::Oids.register_puppet_oids
       Puppet::Face[:certificate, '0.0.1'].generate(@resource[:name], options)
     end
   end

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -25,10 +25,11 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   end
 
   def submit_csr
-      begin
-          Puppet::SSL::CertificateRequest.indirection.save(csr)
-      rescue ArgumentError
-      end
+      # Actually not required, generation submits CSR automatically
+      #begin
+      #    Puppet::SSL::CertificateRequest.indirection.save(csr)
+      #rescue ArgumentError
+      #end
   end
 
   def retrieve_certificate
@@ -169,6 +170,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
         @csr = Puppet::SSL::CertificateRequest.new(@resource[:name])
         @csr.generate(key.content, options)
       end
+      @csr
     end
   end
 

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     if ca_location == 'local'
       sign_certificate
     else
-      retreive_certificate
+      retrieve_certificate
     end
   end
 
@@ -28,11 +28,11 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     # Puppet::SSL::CertificateRequest.indirection.save(csr)
   end
 
-  def retreive_certificate
+  def retrieve_certificate
     unless certificate
       timeout = 0
       certname = @resource[:name]
-      debug "retreiving certificate for #{certname}"
+      debug "retrieving certificate for #{certname}"
       if @resource[:waitforcert]
         timeout = @resource[:waitforcert].to_i
       end
@@ -56,7 +56,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
 
       # If a cert didn't result then fail verbosely
       fail(<<-EOL.gsub(/\s+/, " ").strip) unless cert
-        unable to retreive certificate for #{@resource[:name]}. You may need
+        unable to retrieve certificate for #{@resource[:name]}. You may need
         to sign this certificate on the CA host by running `puppet certificate
         sign #{@resource[:name]} --ca-location=local --mode=master`
       EOL

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -103,8 +103,11 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
 
   def destroy
     Puppet::SSL::Key.indirection.destroy(@resource[:name])
+    @key = nil
     Puppet::SSL::Certificate.indirection.destroy(@resource[:name])
+    @certificate = nil
     Puppet::SSL::CertificateRequest.indirection.destroy(@resource[:name])
+    @csr = nil
   end
 
   def exists?

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -166,6 +166,10 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     end
   end
 
+  def is_valid?
+      certificate.not_after < Time.now
+  end
+
   def debug(msg)
     Puppet.debug "puppet_certificate: #{msg}"
   end

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -169,7 +169,10 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   end
 
   def is_valid?
-      certificate.not_after < Time.now
+      unless certificate.nil?
+          grace_time = @resource[:renewal_grace_period] * 60 * 60 * 24
+          certificate.content.not_after - grace_time > Time.now
+      end
   end
 
   def debug(msg)

--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -48,6 +48,14 @@ Puppet::Type.newtype(:puppet_certificate) do
     desc "The amount of time to wait for the certificate to be signed"
   end
 
+  newparam(:renewal_grace_period) do
+    desc "The number of days before expiration the certificate should be renewed"
+    munge do |v|
+        Integer(v)
+    end
+    defaultto(0)
+  end
+
   newproperty(:dns_alt_names, :array_matching => :all) do
     desc "Alternate DNS names by which the certificate holder may be reached"
   end

--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -4,7 +4,31 @@ Puppet::Type.newtype(:puppet_certificate) do
     Ensures that a given Puppet certificate exists or does not exist.
   EOT
 
-  ensurable
+  ensurable do
+      desc "Create or remove the Puppet certificate"
+      defaultvalues
+      block if block_given?
+
+      newvalue(:valid) do
+          if provider.exists?
+              if provider.is_valid?
+                  if @resource.property(:dns_alt_names)
+                      @resource.property(:dns_alt_names).sync
+                  end
+              else
+                  provider.destroy
+                  provider.create
+              end
+          else
+              provider.create
+          end
+      end
+
+      def insync?(is)
+          return true if should == :valid and provider.is_valid?
+          super
+      end
+  end
 
   newparam(:name) do
     isnamevar


### PR DESCRIPTION
This adds a new `ensure => valid` parameter value, as well as a new `renewal_grace_period` optional parameter.

When a certificate is about to expire (in `renewal_grace_period` from now), the type destroys and recreates it.

Note: this does not take care of cleaning the certificate on the CA.