### PR TITLE
Add clean parameter

### DIFF
--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -108,7 +108,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
       https.ca_file = Puppet.settings[:localcacert]
       resp = https.start { |cx| cx.request(req) }
       if resp.code_type != Net::HTTPNoContent
-          warn "failed to clean certificate: #{resp.body}"
+          warning "failed to clean certificate: #{resp.body}"
       end
   end
 

--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -24,6 +24,12 @@ Puppet::Type.newtype(:puppet_certificate) do
     desc "The amount of time to wait for the certificate to be signed"
   end
 
+  newparam(:clean, :boolean => true) do
+    desc "Delete the certificate from the CA before removing it locally."
+
+    defaultto :false
+  end
+
   newproperty(:dns_alt_names, :array_matching => :all) do
     desc "Alternate DNS names by which the certificate holder may be reached"
   end


### PR DESCRIPTION
This PR adds a clean parameter, which allows to clean the certificate from the CA upon destroying it.

This is useful to keep the CA clean. It requires to add a rule to `auth.conf` on the CA, for example by allowing certificates to clean themselves:

```hocon
        {
            # Allow nodes to delete their own certificate
            match-request: {
                path: "^/puppet-ca/v1/certificate(_status|_request)?/([^/]+)$"
                type: regex
                method: [delete]
            }
            allow: "$2"
            sort-order: 500
            name: "c2c puppet cert clean"
        },
```

Together with #3 and #4, this allows to set up automatic renewal of Puppet certificates, with something along the lines of:

```puppet
    file { "${confdir}/puppet/csr_attributes.yaml":
      ensure  => file,
      owner   => 'root',
      group   => 'root',
      mode    => '0440',
      content => template('blah/csr_attributes.yaml.erb'),
    }
    ~> puppet_certificate { $certname:
      ensure               => valid,
      waitforcert          => 60,
      renewal_grace_period => 20,
      clean                => true,
    }
```